### PR TITLE
Check for successful practice before menu

### DIFF
--- a/addons/sourcemod/scripting/influx_practise.sp
+++ b/addons/sourcemod/scripting/influx_practise.sp
@@ -157,9 +157,10 @@ public Action Cmd_Practise( int client, int args )
     
     if ( !g_bPractising[client] )
     {
-        StartPractising( client );
-        
+        if(StartPractising( client ))
+        {
         FakeClientCommand( client, "sm_pracmenu" );
+        }
     }
     else
     {


### PR DESCRIPTION
Check whether the practice was successful before faking the command pracmenu. If the practice is blocked by another plugin, the pracmenu results in a chat message saying you must be in practice.