### PR TITLE
CP Diff Color & Main Color For Finish Time

### DIFF
--- a/addons/sourcemod/scripting/influx_printcptimes.sp
+++ b/addons/sourcemod/scripting/influx_printcptimes.sp
@@ -85,7 +85,7 @@ public void Influx_OnClientCPSavePost( int client, int cpnum )
         
         FormatEx( szSR, sizeof( szSR ), "SR: {MAINCLR1}%s{CHATCLR} ({%s}%c%s{CHATCLR})",
             szTime,
-            ( c == '-' ) ? "LIGHTRED" : "GREEN",
+            ( c == '-' ) ? "GREEN" : "LIGHTRED",
             c,
             szTimeDif );
     }
@@ -97,7 +97,7 @@ public void Influx_OnClientCPSavePost( int client, int cpnum )
         
         FormatEx( szPB, sizeof( szPB ), "PB: {MAINCLR1}%s{CHATCLR} ({%s}%c%s{CHATCLR})",
             szTime,
-            ( c == '-' ) ? "LIGHTRED" : "GREEN",
+            ( c == '-' ) ? "GREEN" : "LIGHTRED",
             c,
             szTimeDif );
     }
@@ -109,7 +109,7 @@ public void Influx_OnClientCPSavePost( int client, int cpnum )
         
         FormatEx( szBest, sizeof( szBest ), "BEST: {MAINCLR1}%s{CHATCLR} ({%s}%c%s{CHATCLR})",
             szTime,
-            ( c == '-' ) ? "LIGHTRED" : "GREEN",
+            ( c == '-' ) ? "GREEN" : "LIGHTRED",
             c,
             szTimeDif );
     }

--- a/addons/sourcemod/scripting/influx_recchat.sp
+++ b/addons/sourcemod/scripting/influx_recchat.sp
@@ -128,7 +128,7 @@ public void Influx_OnTimerFinishPost( int client, int runid, int mode, int style
         Inf_FormatSeconds( Inf_GetTimeDif( time, prev_best, c ), szForm, sizeof( szForm ), szFormSec );
         
         FormatEx( szRec, sizeof( szRec ), " {CHATCLR}({%s}%c%s{CHATCLR})",
-            isbest ? "LIGHTRED" : "GREEN", // Is new best?
+            isbest ? "GREEN" : "LIGHTRED", // Is new best?
             c,
             szForm );
     }
@@ -185,7 +185,7 @@ public void Influx_OnTimerFinishPost( int client, int runid, int mode, int style
     GetClientName( client, szName, sizeof( szName ) );
     Influx_RemoveChatColors( szName, sizeof( szName ) );
     
-    Influx_PrintToChatEx( _, client, clients, nClients, "{MAINCLR1}%s{CHATCLR} finished {MAINCLR1}%s{CHATCLR} in %s!%s%s%s%s%s%s",
+    Influx_PrintToChatEx( _, client, clients, nClients, "{MAINCLR1}%s{CHATCLR} finished {MAINCLR1}%s{CHATCLR} in {MAINCLR1}%s{CHATCLR}!%s%s%s%s%s%s",
         szName,
         szRun,
         szForm,


### PR DESCRIPTION
Checkpoint text color is oddly reversed. When getting a better time (-) the text should be green and when getting a worse time (+) the text should be red however it's the opposite.

Also the time on the finish message was not set to main color so I changed that to main color as well.