### PR TITLE
registered common commands

### DIFF
--- a/addons/sourcemod/scripting/influx_teams.sp
+++ b/addons/sourcemod/scripting/influx_teams.sp
@@ -51,13 +51,19 @@ public void OnPluginStart()
     RegConsoleCmd( "sm_spawn", Cmd_Spawn );
     RegConsoleCmd( "sm_respawn", Cmd_Spawn );
     
-    
+    RegConsoleCmd( "sm_r", Cmd_Spawn );
+    RegConsoleCmd( "sm_re", Cmd_Spawn );
+    RegConsoleCmd( "sm_rs", Cmd_Spawn );
+    RegConsoleCmd( "sm_restart", Cmd_Spawn );
+    RegConsoleCmd( "sm_start", Cmd_Spawn );
+
+   /* 
     AddCommandListener( Lstnr_Spawn, "sm_r" );
     AddCommandListener( Lstnr_Spawn, "sm_re" );
     AddCommandListener( Lstnr_Spawn, "sm_rs" );
     AddCommandListener( Lstnr_Spawn, "sm_restart" );
     AddCommandListener( Lstnr_Spawn, "sm_start" );
-    
+    */
     
     
     // Blocked commands

--- a/addons/sourcemod/scripting/influx_teams.sp
+++ b/addons/sourcemod/scripting/influx_teams.sp
@@ -56,14 +56,6 @@ public void OnPluginStart()
     RegConsoleCmd( "sm_rs", Cmd_Spawn );
     RegConsoleCmd( "sm_restart", Cmd_Spawn );
     RegConsoleCmd( "sm_start", Cmd_Spawn );
-
-   /* 
-    AddCommandListener( Lstnr_Spawn, "sm_r" );
-    AddCommandListener( Lstnr_Spawn, "sm_re" );
-    AddCommandListener( Lstnr_Spawn, "sm_rs" );
-    AddCommandListener( Lstnr_Spawn, "sm_restart" );
-    AddCommandListener( Lstnr_Spawn, "sm_start" );
-    */
     
     
     // Blocked commands


### PR DESCRIPTION
not sure why it was using the AddCommandListener function, however that was not working for commands typed in chat on csgo.

Using RegConsoleCmd seems to be the optimal solution.